### PR TITLE
Small Ice Climbers term update

### DIFF
--- a/terms.js
+++ b/terms.js
@@ -404,6 +404,12 @@ module.exports = [
       character: 'ice climbers'
    },
    {
+      name: 'ccj fsmash',
+      aliases: ['jump cc fsmash', 'jump cc (fsmash)', 'jump cc nair fsmash', 'jump cc (nair) (fsmash)', 'ccj nair fsmash', 'ccj (fsmash)', 'ccj (nair) (fsmash)'],
+      definition: '(Fsmash) from a cheer cancel jump grab. Perform a CCJ grab and hold the A button used to pummel. Then briefly tap down on the control stick from frames 11 - 20. This will result in [dthrow] (fast fall nair). Lastly, input (fsmash) with c stick or AB smash, it is significantly harder otherwise. Release quickly to have the fsmash come out as early as possible. \nIf you dair, or nana hits the nair but there\’s no fsmash, or you don\’t fastfall, you pressed down too early. All of the above result from pressing down before frame 11. \nhttps://gfycat.com/windingcavernousinvisiblerail \n\nMore details: <https://docs.google.com/document/d/1ggMr0TXWiWE5xf1J2qchvnve0n9Oiloa-X4fwwhigEY/edit?usp=sharing>',
+      character: 'ice climbers'
+   },
+   {
       name: 'chars doc',
       definition: 'Doc that lists what specific things work on which characters, such as utilt (footstool squall), (utilt) footstool as an infinite, and the gimfinite. Work in progress, contact techy#5973 for editing access/corrections. <https://docs.google.com/spreadsheets/d/1WI_xGi1OQ3b0bhrue42OqjrlufqYJQXM2m0FNil6-hw/edit#gid=0>',
       character: 'ice climbers'
@@ -485,12 +491,6 @@ module.exports = [
       name: 'jab interrupt',
       aliases: ['jab desync'],
       definition: 'You can desync off of jab on hit/shield (including on things like Pikmin/hydrant) if you buffer jab out of any state where you can not jab (immediately out of dash, dropping shield, after a move etc etc), then input something for Nana in the next 3 frames. \nhttps://gfycat.com/testyhauntingeastsiberianlaika',
-      character: 'ice climbers'
-   },
-   {
-      name: 'jump cc fsmash',
-      aliases: ['jump cc (fsmash)', 'jump cc nair fsmash', 'jump cc (nair) (fsmash)', 'ccj fsmash', 'ccj nair fsmash', 'ccj (fsmash)', 'ccj (nair) (fsmash)'],
-      definition: '(Fsmash) from a cheer cancel jump grab. Perform a CCJ grab and hold the A button used to pummel. Then briefly tap down on the control stick from frames 11 - 20. This will result in [dthrow] (fast fall nair). Lastly, input (fsmash) with c stick or AB smash, it is significantly harder otherwise. Release quickly to have the fsmash come out as early as possible. \nIf you dair, or nana hits the nair but there\’s no fsmash, or you don\’t fastfall, you pressed down too early. All of the above result from pressing down before frame 11. \nhttps://gfycat.com/windingcavernousinvisiblerail \n\nMore details: <https://docs.google.com/document/d/1ggMr0TXWiWE5xf1J2qchvnve0n9Oiloa-X4fwwhigEY/edit?usp=sharing>',
       character: 'ice climbers'
    },
    {

--- a/terms.js
+++ b/terms.js
@@ -438,8 +438,8 @@ module.exports = [
    },
    {
       name: '[dthrow] (delayed fair)',
-      aliases: ['kakko', 'dthrow delayed fair', '[dthrow] (delayed fair spike)', 'dthrow delayed fair spike',],
-      definition: '[Dthrow] (delayed fair) is a low percent desynced combo starter that, at its core, uses a delayed pre-tumble (fair spike) to give Popo massive frame advantage over the opponent for completely true follow ups. The most common follow ups are [sh landing nair] and [spotdodge] (blizz) [jab 1] \{kakko\}. \nhttps://gfycat.com/lazyfluidelectriceel \n\nPerforming details: <https://docs.google.com/document/d/1fl9yEFLCNua4HzzzpdOclklYXB_qaJCmmxzBCJ0mgJg/edit?usp=sharing>',
+      aliases: ['kakko', 'kakko combo', 'dthrow delayed fair', '[dthrow] (delayed fair spike)', 'dthrow delayed fair spike',],
+      definition: '[Dthrow] (delayed fair) is a low percent desynced combo starter that, at its core, uses a delayed pre-tumble (fair spike) to give Popo massive frame advantage over the opponent for completely true follow ups. The most common follow ups are [sh landing nair] and [spotdodge] (blizz) [jab 1] \{kakko combo\}. \nhttps://gfycat.com/lazyfluidelectriceel \nPercent chart: https://cdn.discordapp.com/attachments/457051061526593536/842867577742295050/Kakko_Chart.png \n\nPerforming details: <https://docs.google.com/document/d/1fl9yEFLCNua4HzzzpdOclklYXB_qaJCmmxzBCJ0mgJg/edit?usp=sharing>',
       character: 'ice climbers'
    },
    {
@@ -580,7 +580,7 @@ module.exports = [
    {
       name: 'soymilk',
       aliases: ['skid turn', 'skid turn desync'],
-      definition: 'Soymilk desync aka "skid turn": Dash in one direction until you enter run, then let go of the control stick to enter skid, then move the control stick in the opposite direction so Popo enters turn, and quickly interrupt the turning animation with any grounded move. If done correctly, Popo will perform the move and Nana will perform a short dash forward. See "Soymilk Gif Guide." \n\nTechnical details: Just like with other run turn desyncs, you have to input the move before Nana goes into turn so that she interprets the turn input as a dash forward. Out of skid, dash interrupts as early as frame 8. So you have to skid, turn, and then input a move at least 8 frames after the original skid, but less than 6 frames after the turn.',
+      definition: 'Soymilk desync aka "skid turn": Dash in one direction until you enter run, then let go of the control stick to enter skid, then move the control stick in the opposite direction so Popo enters turn, and quickly interrupt the turning animation with any grounded move. If done correctly, Popo will perform the move and Nana will perform a short dash forward. See "Soymilk Gif Guide." \n\nTechnical details: Just like with other run turn desynchs, you have to input the move before Nana goes into turn so that she interprets the turn input as a dash forward. Out of skid, dash interrupts as early as frame 8. So you have to skid, turn, and then input a move at least 8 frames after the original skid, but less than 6 frames after the turn.',
       character: 'ice climbers'
    },
    {


### PR DESCRIPTION
Added Demo's percent chart to [dthrow] (delayed fair), added alias of 'kakko combo' to [dthrow] (delayed fair), changed '{kakko}' to '{kakko combo}' in description of [dthrow] (delayed fair). In Soymilk description, changed 'desyncs' back to 'desynchs' in remembrance to Kyu Puff. Changed 'jump cc fsmash' to 'ccj fsmash', put 'jump cc fsmash' as alias in stead of 'ccj fsmash', and reordered alphabetically.